### PR TITLE
Cannot find a solution when particular limits are given

### DIFF
--- a/rectangle_packing_solver/solver.py
+++ b/rectangle_packing_solver/solver.py
@@ -17,7 +17,7 @@ import random
 import signal
 import sys
 from contextlib import redirect_stderr
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 import simanneal
 
@@ -82,15 +82,21 @@ class RectanglePackingProblemAnnealer(simanneal.Annealer):
     def __init__(self, state: List[int], problem: Problem, width_limit: Optional[float] = None, height_limit: Optional[float] = None) -> None:
         self.seqpair = SequencePair()
         self.problem = problem
+
+        # The max possible width and height to deal with the size limit.
+        self.max_possible_width = sum([max(r["width"], r["height"]) if r["rotatable"] else r["width"] for r in problem.rectangles])
+        self.max_possible_height = sum([max(r["width"], r["height"]) if r["rotatable"] else r["height"] for r in problem.rectangles])
+
         self.width_limit = sys.float_info.max
         if width_limit:
             self.width_limit = width_limit
         self.height_limit = sys.float_info.max
         if height_limit:
             self.height_limit = height_limit
+
         super(RectanglePackingProblemAnnealer, self).__init__(state)
 
-    def move(self) -> Union[int, float]:
+    def move(self) -> float:
         """
         Move state (sequence-pair) and return the energy diff.
         """
@@ -98,30 +104,25 @@ class RectanglePackingProblemAnnealer(simanneal.Annealer):
         initial_energy = self.energy()
         initial_state = self.state[:]  # type: ignore
 
-        while True:
-            # Choose two indices and swap them
-            i, j = random.sample(range(self.problem.n), k=2)  # The first and second index
-            offset = random.randint(0, 1) * self.problem.n  # Choose G_{+} (=0) or G_{-} (=1)
+        # Choose two indices and swap them
+        i, j = random.sample(range(self.problem.n), k=2)  # The first and second index
+        offset = random.randint(0, 1) * self.problem.n  # Choose G_{+} (=0) or G_{-} (=1)
 
-            # Swap them (i != j always holds true)
-            self.state[i + offset], self.state[j + offset] = initial_state[j + offset], initial_state[i + offset]  # type: ignore
+        # Swap them (i != j always holds true)
+        self.state[i + offset], self.state[j + offset] = initial_state[j + offset], initial_state[i + offset]  # type: ignore
 
-            # Random rotation
-            if self.problem.rectangles[i]["rotatable"]:
-                if random.randint(0, 1) == 1:
-                    self.state[i + 2 * self.problem.n] = initial_state[i + 2 * self.problem.n] + 1  # type: ignore
+        # Random rotation
+        if self.problem.rectangles[i]["rotatable"]:
+            if random.randint(0, 1) == 1:
+                self.state[i + 2 * self.problem.n] = initial_state[i + 2 * self.problem.n] + 1  # type: ignore
 
-            # We adopt solution if the solution width/height limit is satisfied
-            energy = self.energy()
-            if energy < sys.float_info.max:
-                break
-
-            # Restore the state
-            self.state = initial_state[:]
+        # A solution whose width/height limit is not satisfied has a larger energy.
+        # We adopt a valid solution as the annealing steps proceeds.
+        energy = self.energy()
 
         return energy - initial_energy
 
-    def energy(self) -> Union[int, float]:
+    def energy(self) -> float:
         """
         Calculates the area of bounding box.
         """
@@ -131,16 +132,18 @@ class RectanglePackingProblemAnnealer(simanneal.Annealer):
         seqpair = SequencePair(pair=(gp, gn))
         floorplan = seqpair.decode(problem=self.problem, rotations=rotations)
 
-        # Returns float max, if width/height limit is not satisfied
+        # Returns the max possible area, if width/height limit is not satisfied.
+        # This solution could be chosen in the earlier steps of the annealing,
+        # but would not be chosen in the later steps.
         if floorplan.bounding_box[0] > self.width_limit:
-            return sys.float_info.max
+            return self.max_possible_width * self.max_possible_height
         if floorplan.bounding_box[1] > self.height_limit:
-            return sys.float_info.max
+            return self.max_possible_width * self.max_possible_height
 
-        return floorplan.area
+        return float(floorplan.area)
 
     @classmethod
-    def retrieve_pairs(cls, n: int, state: List[int]) -> Tuple:
+    def retrieve_pairs(cls, n: int, state: List[int]) -> Tuple[List[int], List[int], List[int]]:
         """
         Retrieve G_{+}, G_{-}, and rotations from a state.
         """

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -53,7 +53,7 @@ def test_solver_with_height_limit(example_problem):  # noqa: F811
 
 
 def test_solver_with_width_and_height_limit(example_problem):  # noqa: F811
-    # See PR #X for details.
+    # Note: See PR #23 for details.
     problem = rps.Problem(
         rectangles=[
             {"width": 5, "height": 7, "rotatable": True},

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+
 import rectangle_packing_solver as rps
 from tests.example_data import example_problem  # noqa: F401
 
@@ -48,3 +50,21 @@ def test_solver_with_height_limit(example_problem):  # noqa: F811
     solver = rps.Solver()
     solution = solver.solve(problem=problem, height_limit=6.5)
     assert solution.floorplan.bounding_box[1] <= 6.5
+
+
+def test_solver_with_width_and_height_limit(example_problem):  # noqa: F811
+    # See PR #X for details.
+    problem = rps.Problem(
+        rectangles=[
+            {"width": 5, "height": 7, "rotatable": True},
+            {"width": 5, "height": 7, "rotatable": True},
+            {"width": 5, "height": 7, "rotatable": True},
+            {"width": 5, "height": 7, "rotatable": True},
+            {"width": 5, "height": 7, "rotatable": True},
+        ]
+    )
+    problem = rps.Problem(rectangles=example_problem)
+    for width_limit, height_limit in itertools.product([19, 17, 15], [17, 15, 13]):
+        solution = rps.Solver().solve(problem=problem, width_limit=width_limit, height_limit=height_limit)
+        assert solution.floorplan.bounding_box[0] <= width_limit
+        assert solution.floorplan.bounding_box[1] <= height_limit


### PR DESCRIPTION
Thanks to Magnus's issue reporting!

## To reproduce the issue

```python
problem = rps.Problem(rectangles=[
    {"width": 5, "height": 7, "rotatable": True},
    {"width": 5, "height": 7, "rotatable": True},
    {"width": 5, "height": 7, "rotatable": True},
    {"width": 5, "height": 7, "rotatable": True},
    {"width": 5, "height": 7, "rotatable": True},
])
# when height_limit is less than 19, the issue occurs
solution = rps.Solver().solve(problem=problem, width_limit=17, height_limit=18)
```

## The cause of the issue

A bug in the solver.

At each step of the annealing process, the solution was immediately rejected if it did not satisfy the constraints, and thus the solver was stuck in an infinite loop without reaching a valid solution.

## How to resolve the issue

Solutions that does not satisfy the constraints can be allowed in the earlier annealing steps, and the constraints will eventually satisfied in the final step.

I'll release a next version in a few days.
